### PR TITLE
 #176- 회원 계정 도메인 구현 및 erd 반영

### DIFF
--- a/src/main/java/org/fastcampus/projectboard/domain/UserAccount.java
+++ b/src/main/java/org/fastcampus/projectboard/domain/UserAccount.java
@@ -1,0 +1,58 @@
+package org.fastcampus.projectboard.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.Objects;
+
+@Getter
+@ToString
+@Table(indexes = {
+        @Index(columnList = "userId"),
+        @Index(columnList = "email", unique = true),
+        @Index(columnList = "createdAt"),
+        @Index(columnList = "createdBy")
+})
+@Entity
+public class UserAccount extends AuditingFields {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter @Column(nullable = false, length = 50) private String userId;
+    @Setter @Column(nullable = false) private String userPassword;
+
+    @Setter @Column(length = 100) private String email;
+    @Setter @Column(length = 100) private String nickname;
+    @Setter private String memo;
+
+
+    protected UserAccount() {}
+
+    private UserAccount(String userId, String userPassword, String email, String nickname, String memo) {
+        this.userId = userId;
+        this.userPassword = userPassword;
+        this.email = email;
+        this.nickname = nickname;
+        this.memo = memo;
+    }
+
+    public static UserAccount of(String userId, String userPassword, String email, String nickname, String memo) {
+        return new UserAccount(userId, userPassword, email, nickname, memo);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserAccount userAccount)) return false;
+        return id != null && id.equals(userAccount.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+}

--- a/src/main/java/org/fastcampus/projectboard/repository/UserAccountRepository.java
+++ b/src/main/java/org/fastcampus/projectboard/repository/UserAccountRepository.java
@@ -1,0 +1,7 @@
+package org.fastcampus.projectboard.repository;
+
+import org.fastcampus.projectboard.domain.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,3 +1,9 @@
+-- 테스트 계정
+-- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
+insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
+    ('duzi', 'asdf1234', 'duzi', 'duzi@mail.com', 'I am Duzi.', now(), 'uno', now(), 'duzi')
+;
+
 insert into article (title, content, hashtag, created_by, modified_by, created_at, modified_at) values ('Aliquam non mauris.', 'Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.', 'Yellow', 'Niels', 'Hagan', '2023-12-06 21:25:31', '2023-05-29 08:12:49');
 insert into article (title, content, hashtag, created_by, modified_by, created_at, modified_at) values ('Phasellus sit amet erat.', 'Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus.', null, 'Felecia', 'Candra', '2023-09-09 18:25:35', '2024-02-11 21:54:14');
 insert into article (title, content, hashtag, created_by, modified_by, created_at, modified_at) values ('Suspendisse accumsan tortor quis turpis.', 'Curabitur at ipsum ac tellus semper interdum. Mauris ullamcorper purus sit amet nulla. Quisque arcu libero, rutrum ac, lobortis vel, dapibus at, diam.', null, 'Bamby', 'Rhodia', '2023-10-22 07:58:32', '2023-08-31 15:16:12');

--- a/src/test/java/org/fastcampus/projectboard/controller/DataRestTest.java
+++ b/src/test/java/org/fastcampus/projectboard/controller/DataRestTest.java
@@ -11,7 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -84,5 +84,19 @@ public class DataRestTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.valueOf("application/hal+json")))
                 .andDo(print());
+    }
+
+    @DisplayName("[api] 회원 관련 API 는 일체 제공하지 않는다.")
+    @Test
+    void givenNothing_whenRequestingUserAccounts_thenThrowsException() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(post("/api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(put("/api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(patch("/api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(delete("/api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(head("/api/userAccounts")).andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION
`UserAccount` 이름으로 회원 계정 도메인 생성 `user`, `account` 등은 mysql 예약어이므로 피함 필드명도 mysql 예약어를 의식하여 정함  테스트 데이터에 임의 계정 1개 등록 테스트용이지만 패스워드가 노출되는 방식이므로 고민 필요  회원 정보는 API 로 노출되지 않았으면 한다. 이에 테스트에 404 not found 를 확인하는 테스트 추가 간단하게 모든 http 메소드에 대응